### PR TITLE
Remove annotation endpoint

### DIFF
--- a/mirador-001.html
+++ b/mirador-001.html
@@ -35,14 +35,7 @@
           }],
           availableAnnotationDrawingTools: [
             'Rectangle', 'Ellipse', 'Polygon'
-          ],
-          annotationEndpoint: {
-            name: 'Simple Annotation Store Endpoint',
-            module: 'SimpleASEndpoint',
-            options: {
-              url: 'https://iiif.universiteitleiden.nl/anno/annotation',
-            }
-          }
+          ]
         });
       });
     </script>

--- a/mirador-002.html
+++ b/mirador-002.html
@@ -36,14 +36,7 @@
           }],
           availableAnnotationDrawingTools: [
             'Rectangle', 'Ellipse', 'Polygon'
-          ],
-          annotationEndpoint: {
-            name: 'Simple Annotation Store Endpoint',
-            module: 'SimpleASEndpoint',
-            options: {
-              url: 'https://iiif.universiteitleiden.nl/anno/annotation',
-            }
-          }
+          ]
         });
       });
     </script>

--- a/mirador-003.html
+++ b/mirador-003.html
@@ -36,14 +36,7 @@
           }],
           availableAnnotationDrawingTools: [
             'Rectangle', 'Ellipse', 'Polygon'
-          ],
-          annotationEndpoint: {
-            name: 'Simple Annotation Store Endpoint',
-            module: 'SimpleASEndpoint',
-            options: {
-              url: 'https://iiif.universiteitleiden.nl/anno/annotation',
-            }
-          }
+          ]
         });
       });
     </script>

--- a/mirador-004.html
+++ b/mirador-004.html
@@ -36,14 +36,7 @@
           }],
           availableAnnotationDrawingTools: [
             'Rectangle', 'Ellipse', 'Polygon'
-          ],
-          annotationEndpoint: {
-            name: 'Simple Annotation Store Endpoint',
-            module: 'SimpleASEndpoint',
-            options: {
-              url: 'https://iiif.universiteitleiden.nl/anno/annotation',
-            }
-          }
+          ]
         });
       });
     </script>

--- a/mirador-005.html
+++ b/mirador-005.html
@@ -36,14 +36,7 @@
           }],
           availableAnnotationDrawingTools: [
             'Rectangle', 'Ellipse', 'Polygon'
-          ],
-          annotationEndpoint: {
-            name: 'Simple Annotation Store Endpoint',
-            module: 'SimpleASEndpoint',
-            options: {
-              url: 'https://iiif.universiteitleiden.nl/anno/annotation',
-            }
-          }
+          ]
         });
       });
     </script>


### PR DESCRIPTION
The annotation endpoint in the Mirador viewer only worked on the campus.
The manifests have been updated to load annotations differently.